### PR TITLE
Support multiprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ Install the following packages along with their dependencies:
 - [Numpy](http://www.numpy.org/)
 - [tqdm](https://pypi.python.org/pypi/tqdm#installation) - Required for displaying the 
   progress bar.
-- [Matplotlib](https://matplotlib.org/) - (Optional) For plotting the frames of a video
 
 ```bash
-    pip install ffmpeg-python numpy tqdm matplotlib
+    pip install ffmpeg-python numpy tqdm
 ```

--- a/conda_build/mydia/meta.yaml
+++ b/conda_build/mydia/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - python    
     - ffmpeg-python
     - numpy
-    - matplotlib
     - tqdm
   run:
     - ffmpeg-python
@@ -35,4 +34,3 @@ about:
   license_file: 
   summary: A simple and efficient wrapper for reading videos as NumPy tensors
   doc_url: https://mrinaljain17.github.io/mydia/
-  dev_url: 

--- a/mydia/mydia.py
+++ b/mydia/mydia.py
@@ -11,6 +11,7 @@ __version__ = "2.1.1"
 __author__ = "Mrinal Jain"
 
 import warnings
+from multiprocessing import Pool, cpu_count
 from typing import NamedTuple
 
 import ffmpeg
@@ -172,7 +173,61 @@ class Videos(object):
         else:
             raise ValueError("Invalid value of 'data_format'")
 
-        self.random_state = np.random.RandomState(random_state)
+        self.random_state = random_state
+
+    def read(self, paths, verbose=1, workers=0):
+        """Function to read videos
+
+        :param paths: A list of paths/path of the video(s) to be read.
+        :type paths: str or list[str]
+
+        :param verbose: If set to 0, the progress bar will be disabled.
+        :type verbose: int
+        
+        :return: 
+            A 5-dimensional tensor, whose shape will depend on the value of ``data_format``.
+            
+            * For ``"channels_last"``: The tensor will have shape 
+              ``(<samples>, <frames>, <height>, <width>, <channels>)``
+            * For ``"channels_first"``: The tensor will have shape 
+              ``(<samples>, <channels>, <frames>, <height>, <width>)``
+
+        :rtype: :obj:`numpy.ndarray`
+
+        :raises ValueError: If ``paths`` is neither a string, not a list of strings.
+        :raises IndexError: 
+            If ``num_frames`` is set to a value greater than the total number of frames 
+            available in the video.
+
+        .. important::
+
+           If multiple videos are to be read, then each video should have the same dimension 
+           ``(frames, height, width)``, otherwise they cannot be stacked into a single 
+           tensor. Therefore, the user **must** use the parameters ``target_size`` and 
+           ``num_frames`` to make sure of this.
+        
+        """
+
+        if not isinstance(paths, list):
+            if isinstance(paths, str):
+                paths = [paths]
+            else:
+                raise ValueError("Invalid value of 'paths'")
+        disable = False
+        if verbose == 0:
+            disable = True
+
+        video_tensor = None
+        if (isinstance(workers, int)) and (workers > 0):
+            video_tensor = self._read_parallel(paths, disable, workers)
+        else:
+            paths_iterator = tqdm(paths, unit="videos", disable=disable)
+            video_tensor = np.vstack(map(self._read_video, paths_iterator))
+
+        if self.data_format == "channels_first":
+            video_tensor = np.transpose(video_tensor, axes=(0, 4, 1, 2, 3))
+
+        return video_tensor
 
     def _read_video(self, path):
         """Used internally by :func:`read()` to read in a **single** video.
@@ -275,55 +330,23 @@ class Videos(object):
 
         # The method will return nothing if an exception is encountered
 
-    def read(self, paths, verbose=1):
-        """Function to read videos
-
-        :param paths: A list of paths/path of the video(s) to be read.
-        :type paths: str or list[str]
-
-        :param verbose: If set to 0, the progress bar will be disabled.
-        :type verbose: int
-        
-        :return: 
-            A 5-dimensional tensor, whose shape will depend on the value of ``data_format``.
-            
-            * For ``"channels_last"``: The tensor will have shape 
-              ``(<samples>, <frames>, <height>, <width>, <channels>)``
-            * For ``"channels_first"``: The tensor will have shape 
-              ``(<samples>, <channels>, <frames>, <height>, <width>)``
-
-        :rtype: :obj:`numpy.ndarray`
-
-        :raises ValueError: If ``paths`` is neither a string, not a list of strings.
-        :raises IndexError: 
-            If ``num_frames`` is set to a value greater than the total number of frames 
-            available in the video.
-
-        .. important::
-
-           If multiple videos are to be read, then each video should have the same dimension 
-           ``(frames, height, width)``, otherwise they cannot be stacked into a single 
-           tensor. Therefore, the user **must** use the parameters ``target_size`` and 
-           ``num_frames`` to make sure of this.
+    def _read_parallel(self, paths, disable, workers):
+        """
         
         """
+        max_workers = cpu_count()
+        if workers > max_workers:
+            warnings.warn(f"The CPU can support maximum {max_workers} workers.")
+            workers = max_workers
+        list_of_videos = []
+        with Pool(workers) as pool:
+            with tqdm(total=len(paths), unit="videos", disable=disable) as pbar:
+                for _, result in enumerate(pool.imap(self._read_video, paths)):
+                    list_of_videos.append(result)
+                    pbar.update()
+        pool.join()
 
-        if not isinstance(paths, list):
-            if isinstance(paths, str):
-                paths = [paths]
-            else:
-                raise ValueError("Invalid value of 'paths'")
-        disable = False
-        if verbose == 0:
-            disable = True
-
-        paths_iterator = tqdm(paths, unit="videos", disable=disable)
-        video_tensor = np.vstack(map(self._read_video, paths_iterator))
-
-        if self.data_format == "channels_first":
-            video_tensor = np.transpose(video_tensor, axes=(0, 4, 1, 2, 3))
-
-        return video_tensor
+        return np.vstack(list_of_videos)
 
 
 def make_grid(video, num_col=3, padding=5):

--- a/mydia/utils.py
+++ b/mydia/utils.py
@@ -15,16 +15,15 @@ def _mode_auto(total_frames: int, num_frames: int, fps: int, *args) -> List[int]
 
 
 def _mode_random(
-    total_frames: int, num_frames: int, fps: int, random_state: np.random.RandomState
+    total_frames: int, num_frames: int, fps: int, random_state: int
 ) -> List[int]:
     """The ``random`` mode for frame extraction
 
     Refer to the documentation of the class :class:`Videos` for further details.
     
     """
-    return np.sort(
-        random_state.choice(total_frames, size=num_frames, replace=False)
-    ).tolist()
+    r = np.random.RandomState(random_state)
+    return np.sort(r.choice(total_frames, size=num_frames, replace=False)).tolist()
 
 
 def _mode_first(total_frames: int, num_frames: int, fps: int, *args) -> List[int]:

--- a/tests/test_videos.py
+++ b/tests/test_videos.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 from mydia import Videos, make_grid
 
 path = "./docs/examples/sample_video/bigbuckbunny.mp4"
@@ -41,13 +42,26 @@ def test_custom_frame():
 
 
 def test_random_repeatability():
-    reader_1 = Videos(target_size=(360, 240), to_gray=True, num_frames=36, mode="random", random_state=26)
-    reader_2 = Videos(target_size=(360, 240), to_gray=True, num_frames=36, mode="random", random_state=26)
+    reader_1 = Videos(
+        target_size=(360, 240),
+        to_gray=True,
+        num_frames=36,
+        mode="random",
+        random_state=26,
+    )
+    reader_2 = Videos(
+        target_size=(360, 240),
+        to_gray=True,
+        num_frames=36,
+        mode="random",
+        random_state=26,
+    )
 
     video_1 = reader_1.read(path, verbose=0)
     video_2 = reader_2.read(path, verbose=0)
 
     assert np.array_equal(video_1, video_2) == True
+
 
 def test_make_grid():
     target_width = 360
@@ -56,7 +70,9 @@ def test_make_grid():
     num_frames = 36
     num_col = 5
 
-    reader = Videos(target_size=(target_width, target_height), to_gray=False, num_frames=num_frames)
+    reader = Videos(
+        target_size=(target_width, target_height), to_gray=False, num_frames=num_frames
+    )
     video = reader.read(path, verbose=0)
     num_row = int(np.ceil(num_frames / num_col))
     grid = make_grid(video[0], num_col=num_col, padding=padding)


### PR DESCRIPTION
- This PR adds support for reading videos in parallel, using the `multiprocessing` module in the python standard library. The `Videos.read()` function now supports a parameter `workers` that determines the number of CPUs to be used.
- Also, there was a bug in seeding the random number generator when setting the `mode` to "random" which prevented the reproducibility of frames. That issue has now been fixed, and the related docstrings have been updated.